### PR TITLE
feat: add multi-agent farcaster support

### DIFF
--- a/frontend/src/app/api/copilotkit/route.ts
+++ b/frontend/src/app/api/copilotkit/route.ts
@@ -15,10 +15,16 @@ const runtime = new CopilotRuntime({
         langGraphPlatformEndpoint({
             deploymentUrl: deploymentUrl!,
             langsmithApiKey: process.env.LANGSMITH_API_KEY!,
-            agents: [{
-                name: 'agent',
-                description: 'Research assistant',
-            }],
+            agents: [
+                {
+                    name: 'agent',
+                    description: 'Research assistant',
+                },
+                {
+                    name: 'farcaster',
+                    description: 'Farcaster agent',
+                }
+            ],
         })
     ]
 });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { CopilotKit } from "@copilotkit/react-core";
 import { Noto_Serif, Lato } from "next/font/google";
 import { ResearchProvider } from "@/components/research-context";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { AgentProvider } from "@/components/agent-context";
 
 const lato = Lato({
     subsets: ['latin'],
@@ -42,11 +43,13 @@ export default function RootLayout({
                     showDevConsole={false}
                     agent="agent"
                 >
-                    <TooltipProvider>
-                        <ResearchProvider>
-                            {children}
-                        </ResearchProvider>
-                    </TooltipProvider>
+                    <AgentProvider>
+                        <TooltipProvider>
+                            <ResearchProvider>
+                                {children}
+                            </ResearchProvider>
+                        </TooltipProvider>
+                    </AgentProvider>
                 </CopilotKit>
             </body>
         </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@
 import Chat from "@/components/chat";
 import { useEffect, useRef, useState } from "react";
 import { GripVertical } from "lucide-react";
-import { useCoAgentStateRender, useLangGraphInterrupt } from "@copilotkit/react-core";
+import { useCoAgentStateRender, useLangGraphInterrupt, useCopilotContext } from "@copilotkit/react-core";
 
 import { ResearchState } from "@/lib/types";
 import { Progress } from "@/components/progress";
@@ -12,6 +12,7 @@ import { useResearch } from "@/components/research-context";
 import { DocumentsView } from "@/components/documents-view";
 import { useStreamingContent } from '@/lib/hooks/useStreamingContent';
 import { ProposalViewer } from "@/components/structure-proposal-viewer";
+import { useAgent } from "@/components/agent-context";
 
 const CHAT_MIN_WIDTH = 30;
 const CHAT_MAX_WIDTH = 50;
@@ -21,17 +22,23 @@ export default function HomePage() {
     const dividerRef = useRef<HTMLDivElement>(null)
     const containerRef = useRef<HTMLDivElement>(null)
     const { state: researchState, setResearchState } = useResearch()
+    const { agentType } = useAgent()
+    const { setAgentSession } = useCopilotContext()
 
     // Handle all "logs" - The loading states that show what the agent is doing
     useCoAgentStateRender<ResearchState>({
-        name: 'agent',
+        name: agentType,
         render: ({ state }) => {
             if (state.logs?.length > 0) {
                 return <Progress logs={state.logs} />;
             }
             return null;
         },
-    }, [researchState]);
+    }, [researchState, agentType]);
+
+    useEffect(() => {
+        setAgentSession({ agentName: agentType })
+    }, [agentType, setAgentSession])
 
     useLangGraphInterrupt({
         render: ({ resolve, event }) => {

--- a/frontend/src/components/agent-context.tsx
+++ b/frontend/src/components/agent-context.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+export type AgentType = 'agent' | 'farcaster'
+
+interface AgentContextType {
+  agentType: AgentType
+  setAgentType: (type: AgentType) => void
+}
+
+const AgentContext = createContext<AgentContextType | undefined>(undefined)
+
+export function AgentProvider({ children }: { children: ReactNode }) {
+  const [agentType, setAgentType] = useState<AgentType>('agent')
+  return (
+    <AgentContext.Provider value={{ agentType, setAgentType }}>
+      {children}
+    </AgentContext.Provider>
+  )
+}
+
+export function useAgent() {
+  const ctx = useContext(AgentContext)
+  if (!ctx) {
+    throw new Error('useAgent must be used within an AgentProvider')
+  }
+  return ctx
+}

--- a/frontend/src/components/chat.tsx
+++ b/frontend/src/components/chat.tsx
@@ -1,21 +1,36 @@
 'use client'
 
 import { CopilotChat } from "@copilotkit/react-ui";
-import { INITIAL_MESSAGE, MAIN_CHAT_INSTRUCTIONS, MAIN_CHAT_TITLE } from "@/lib/consts";
+import {
+  FARCASTER_CHAT_INSTRUCTIONS,
+  FARCASTER_CHAT_TITLE,
+  FARCASTER_INITIAL_MESSAGE,
+  INITIAL_MESSAGE,
+  MAIN_CHAT_INSTRUCTIONS,
+  MAIN_CHAT_TITLE,
+} from "@/lib/consts";
 // TODO: fix
 // @ts-expect-error -- ignore
 import { CopilotChatProps } from "@copilotkit/react-ui/dist/components/chat/Chat";
+import { useAgent } from "@/components/agent-context";
 
 export default function Chat(props: CopilotChatProps) {
+  const { agentType } = useAgent();
+
+  const instructions =
+    agentType === "farcaster" ? FARCASTER_CHAT_INSTRUCTIONS : MAIN_CHAT_INSTRUCTIONS;
+
+  const labels = {
+    title: agentType === "farcaster" ? FARCASTER_CHAT_TITLE : MAIN_CHAT_TITLE,
+    initial: agentType === "farcaster" ? FARCASTER_INITIAL_MESSAGE : INITIAL_MESSAGE,
+  };
+
   return (
-      <CopilotChat
-          instructions={MAIN_CHAT_INSTRUCTIONS}
-          labels={{
-              title: MAIN_CHAT_TITLE,
-              initial: INITIAL_MESSAGE,
-          }}
-          className="h-full w-full font-noto"
-          {...props}
-      />
-  )
+    <CopilotChat
+      instructions={instructions}
+      labels={labels}
+      className="h-full w-full font-noto"
+      {...props}
+    />
+  );
 }

--- a/frontend/src/components/research-context.tsx
+++ b/frontend/src/components/research-context.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useState, ReactNode, useEffect } from 'react
 import type { ResearchState } from '@/lib/types'
 import { useCoAgent } from "@copilotkit/react-core";
 import useLocalStorage from "@/lib/hooks/useLocalStorage";
+import { useAgent } from "@/components/agent-context";
 
 interface ResearchContextType {
     state: ResearchState;
@@ -17,8 +18,9 @@ const ResearchContext = createContext<ResearchContextType | undefined>(undefined
 
 export function ResearchProvider({ children }: { children: ReactNode }) {
     const [sourcesModalOpen, setSourcesModalOpen] = useState<boolean>(false)
+    const { agentType } = useAgent();
     const { state: coAgentState, setState: setCoAgentsState, run } = useCoAgent<ResearchState>({
-        name: 'agent',
+        name: agentType,
         initialState: {},
     });
     // @ts-expect-error -- force null

--- a/frontend/src/components/toolbar.tsx
+++ b/frontend/src/components/toolbar.tsx
@@ -2,6 +2,7 @@ import { FileText, RefreshCcw } from "lucide-react";
 import { useResearch } from "@/components/research-context";
 import { LucideIcon } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { AgentType, useAgent } from "@/components/agent-context";
 
 interface NavButtonProps {
     icon: LucideIcon;
@@ -19,6 +20,7 @@ function NavButton({ icon: Icon, onClick, disabled }: NavButtonProps) {
 
 export default function Toolbar() {
     const { setSourcesModalOpen, state } = useResearch();
+    const { agentType, setAgentType } = useAgent();
 
     return (
         <div
@@ -44,6 +46,17 @@ export default function Toolbar() {
                         <p>View Sources</p>
                     </TooltipContent>
                 </Tooltip>
+            </div>
+            <div className="space-y-2">
+                {[{ label: 'Research', type: 'agent' as AgentType }, { label: 'Farcaster', type: 'farcaster' as AgentType }].map((opt) => (
+                    <button
+                        key={opt.type}
+                        onClick={() => setAgentType(opt.type)}
+                        className={`text-sm ${agentType === opt.type ? 'font-bold' : ''}`}
+                    >
+                        {opt.label}
+                    </button>
+                ))}
             </div>
             {/*<Avatar className="border-2 border-[#8B4513]/20">*/}
             {/*    <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn"/>*/}

--- a/frontend/src/lib/consts.ts
+++ b/frontend/src/lib/consts.ts
@@ -1,6 +1,13 @@
 export const MAIN_CHAT_INSTRUCTIONS = `
     You are a helpful research assistant, set to help the user with conduction and writing a research paper on any topic.
-`
+`;
 
-export const MAIN_CHAT_TITLE = 'Research Assistant'
-export const INITIAL_MESSAGE = 'Hi! 👋 How can I assist you today?'
+export const MAIN_CHAT_TITLE = 'Research Assistant';
+export const INITIAL_MESSAGE = 'Hi! 👋 How can I assist you today?';
+
+export const FARCASTER_CHAT_INSTRUCTIONS = `
+    You are a helpful Farcaster assistant ready to help the user with Farcaster frames and posts.
+`;
+
+export const FARCASTER_CHAT_TITLE = 'Farcaster Agent';
+export const FARCASTER_INITIAL_MESSAGE = 'Hi! 👋 How can I help you with Farcaster today?';


### PR DESCRIPTION
## Summary
- define Farcaster chat instructions and titles
- allow switching agents via new context and toolbar selector
- route chat requests to selected agent

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6c30316f4832e800b643d55bdf357