### PR TITLE
feat: add query router

### DIFF
--- a/frontend/src/components/chat.tsx
+++ b/frontend/src/components/chat.tsx
@@ -12,10 +12,19 @@ import {
 // TODO: fix
 // @ts-expect-error -- ignore
 import { CopilotChatProps } from "@copilotkit/react-ui/dist/components/chat/Chat";
-import { useAgent } from "@/components/agent-context";
+import { AgentType, useAgent } from "@/components/agent-context";
+import { routeAgent } from "@/lib/router";
+import { useCallback } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-export default function Chat(props: CopilotChatProps) {
-  const { agentType } = useAgent();
+export default function Chat({ onSubmitMessage, ...props }: CopilotChatProps) {
+  const { agentType, setAgentType } = useAgent();
 
   const instructions =
     agentType === "farcaster" ? FARCASTER_CHAT_INSTRUCTIONS : MAIN_CHAT_INSTRUCTIONS;
@@ -25,13 +34,43 @@ export default function Chat(props: CopilotChatProps) {
     initial: agentType === "farcaster" ? FARCASTER_INITIAL_MESSAGE : INITIAL_MESSAGE,
   };
 
+  const handleSubmitMessage = useCallback(
+    async (message: string) => {
+      const { agent, confidence } = routeAgent(message);
+      if (agent && confidence >= 0.6) {
+        setAgentType(agent);
+      }
+      if (onSubmitMessage) {
+        await onSubmitMessage(message);
+      }
+    },
+    [onSubmitMessage, setAgentType]
+  );
+
   return (
-    <CopilotChat
-      key={agentType}
-      instructions={instructions}
-      labels={labels}
-      className="h-full w-full font-noto"
-      {...props}
-    />
+    <div className="h-full w-full font-noto flex flex-col">
+      <div className="flex justify-end p-2">
+        <Select
+          value={agentType}
+          onValueChange={(v) => setAgentType(v as AgentType)}
+        >
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="Select agent" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="agent">Research</SelectItem>
+            <SelectItem value="farcaster">Farcaster</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <CopilotChat
+        key={agentType}
+        instructions={instructions}
+        labels={labels}
+        className="h-full w-full flex-1"
+        onSubmitMessage={handleSubmitMessage}
+        {...props}
+      />
+    </div>
   );
 }

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -1,0 +1,54 @@
+import { AgentType } from "@/components/agent-context";
+
+export interface RouteResult {
+  agent: AgentType | null;
+  confidence: number;
+}
+
+const FARCASTER_KEYWORDS = [
+  "farcaster",
+  "cast",
+  "warpcast",
+  "frame",
+  "channel",
+  "follow",
+  "feed",
+  "user",
+  "fc",
+];
+
+const RESEARCH_KEYWORDS = [
+  "research",
+  "report",
+  "source",
+  "outline",
+  "section",
+  "write",
+  "paper",
+  "article",
+  "topic",
+  "summary",
+  "document",
+];
+
+export function routeAgent(query: string): RouteResult {
+  const text = query.toLowerCase();
+  let fScore = 0;
+  for (const k of FARCASTER_KEYWORDS) {
+    if (text.includes(k)) fScore++;
+  }
+  let rScore = 0;
+  for (const k of RESEARCH_KEYWORDS) {
+    if (text.includes(k)) rScore++;
+  }
+  if (fScore === 0 && rScore === 0) {
+    return { agent: null, confidence: 0 };
+  }
+  if (fScore > rScore) {
+    return { agent: "farcaster", confidence: fScore / (fScore + rScore) };
+  }
+  if (rScore > fScore) {
+    return { agent: "agent", confidence: rScore / (fScore + rScore) };
+  }
+  return { agent: null, confidence: 0.5 };
+}


### PR DESCRIPTION
## Summary
- add keyword-based router for selecting research or farcaster agent
- integrate router into chat submission and expose agent selector override

## Testing
- `cd open-research-farcaster/frontend && pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6c6fd1dec832eac1485bab5a72f0c