### PR TITLE
Flush agent selection before message submit

### DIFF
--- a/frontend/src/components/chat.tsx
+++ b/frontend/src/components/chat.tsx
@@ -15,6 +15,7 @@ import { CopilotChatProps } from "@copilotkit/react-ui/dist/components/chat/Chat
 import { AgentType, useAgent } from "@/components/agent-context";
 import { routeAgent } from "@/lib/router";
 import { useCallback } from "react";
+import { flushSync } from "react-dom";
 import {
   Select,
   SelectContent,
@@ -38,7 +39,7 @@ export default function Chat({ onSubmitMessage, ...props }: CopilotChatProps) {
     async (message: string) => {
       const { agent, confidence } = routeAgent(message);
       if (agent && confidence >= 0.6) {
-        setAgentType(agent);
+        flushSync(() => setAgentType(agent));
       }
       if (onSubmitMessage) {
         await onSubmitMessage(message);


### PR DESCRIPTION
## Summary
- import `flushSync` from `react-dom`
- ensure agent type state is flushed before submitting chat messages

## Testing
- `pnpm run lint`
- manual check via Node script that a "view cast" query uses the Farcaster agent immediately

------
https://chatgpt.com/codex/tasks/task_e_68a7dd0e7d14832eb63d6ef897d4f70d