### PR TITLE
feat: persist last agent selection

### DIFF
--- a/frontend/src/components/chat.tsx
+++ b/frontend/src/components/chat.tsx
@@ -13,7 +13,7 @@ import {
 // @ts-expect-error -- ignore
 import { CopilotChatProps } from "@copilotkit/react-ui/dist/components/chat/Chat";
 import { AgentType, useAgent } from "@/components/agent-context";
-import { routeAgent } from "@/lib/router";
+import { routeAgent, setLastAgent } from "@/lib/router";
 import { useCallback } from "react";
 import { flushSync } from "react-dom";
 import {
@@ -39,7 +39,10 @@ export default function Chat({ onSubmitMessage, ...props }: CopilotChatProps) {
     async (message: string) => {
       const { agent, confidence } = routeAgent(message);
       if (agent && confidence >= 0.6) {
-        flushSync(() => setAgentType(agent));
+        flushSync(() => {
+          setAgentType(agent);
+          setLastAgent(agent);
+        });
       }
       if (onSubmitMessage) {
         await onSubmitMessage(message);

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -1,5 +1,11 @@
 import { AgentType } from "@/components/agent-context";
 
+let lastAgent: AgentType | null = null;
+
+export function setLastAgent(agent: AgentType | null) {
+  lastAgent = agent;
+}
+
 export interface RouteResult {
   agent: AgentType | null;
   confidence: number;
@@ -42,7 +48,7 @@ export function routeAgent(query: string): RouteResult {
     if (text.includes(k)) rScore++;
   }
   if (fScore === 0 && rScore === 0) {
-    return { agent: null, confidence: 0 };
+    return { agent: lastAgent, confidence: 0 };
   }
   if (fScore > rScore) {
     return { agent: "farcaster", confidence: fScore / (fScore + rScore) };
@@ -50,5 +56,5 @@ export function routeAgent(query: string): RouteResult {
   if (rScore > fScore) {
     return { agent: "agent", confidence: rScore / (fScore + rScore) };
   }
-  return { agent: null, confidence: 0.5 };
+  return { agent: lastAgent, confidence: 0.5 };
 }


### PR DESCRIPTION
## Summary
- track last classified agent and fallback to it when message has no keywords
- provide setLastAgent helper and wire up chat to keep router state

## Testing
- `cd frontend && pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a7f3e45fa8832e99f02538342ab900