### PR TITLE
Add Farcaster regex routing and tests

### DIFF
--- a/frontend/src/lib/router.test.ts
+++ b/frontend/src/lib/router.test.ts
@@ -1,0 +1,18 @@
+import { routeAgent } from './router';
+
+describe('routeAgent Farcaster detection', () => {
+  it('identifies FID prefixed queries regardless of case', () => {
+    const result = routeAgent('FID 12345');
+    expect(result.agent).toBe('farcaster');
+  });
+
+  it('identifies numeric-only queries as Farcaster', () => {
+    const result = routeAgent('12345');
+    expect(result.agent).toBe('farcaster');
+  });
+
+  it('identifies Farcaster keyword regardless of case', () => {
+    const result = routeAgent('FARCASTER user');
+    expect(result.agent).toBe('farcaster');
+  });
+});

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -23,6 +23,12 @@ const FARCASTER_KEYWORDS = [
   "fc",
 ];
 
+const FARCASTER_PATTERNS = [
+  /\bfid[:\s]*\d+\b/, // "fid 123" or "fid:123"
+  /\bfarcaster\b/, // explicit farcaster mentions
+  /^\d+$/ // numeric id without prefix
+];
+
 const RESEARCH_KEYWORDS = [
   "research",
   "report",
@@ -38,10 +44,13 @@ const RESEARCH_KEYWORDS = [
 ];
 
 export function routeAgent(query: string): RouteResult {
-  const text = query.toLowerCase();
+  const text = query.toLowerCase().trim();
   let fScore = 0;
   for (const k of FARCASTER_KEYWORDS) {
     if (text.includes(k)) fScore++;
+  }
+  for (const r of FARCASTER_PATTERNS) {
+    if (r.test(text)) fScore++;
   }
   let rScore = 0;
   for (const k of RESEARCH_KEYWORDS) {


### PR DESCRIPTION
## Summary
- broaden Farcaster detection with regex patterns for FID, Farcaster and numeric IDs
- normalize queries to lowercase before routing
- add tests covering minimal farcaster cues

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7feec6108832e93197528c373bb6e